### PR TITLE
SchemaHandler doesn't route

### DIFF
--- a/pkg/sinks/generic/router_test.go
+++ b/pkg/sinks/generic/router_test.go
@@ -15,13 +15,13 @@ import (
 
 var _ = Describe("router", func() {
 	var (
-		ctx                     context.Context
-		router                  generic.Router
-		async                   generic.AsyncInserter
-		backend                 fakeBackend
-		exampleNS, dogNS, catNS changelog.Namespace
-		example, dog, cat       *fakeInserter
-		cancel                  func()
+		ctx                              context.Context
+		router                           generic.Router
+		async                            generic.AsyncInserter
+		backend                          fakeBackend
+		exampleRoute, dogRoute, catRoute generic.Route
+		example, dog, cat                *fakeInserter
+		cancel                           func()
 
 		suite = AsyncInserterSuite{
 			// We don't use the provided fakeBackend here, as we connect the router to the
@@ -29,21 +29,21 @@ var _ = Describe("router", func() {
 			New: func(_ fakeBackend) generic.AsyncInserter {
 				router = generic.NewRouter(logger)
 
-				exampleResult := router.Register(ctx, exampleNS, generic.WrapAsync(example))
+				exampleResult := router.Register(ctx, exampleRoute, generic.WrapAsync(example))
 				ExpectResolveSuccess(exampleResult.Get(ctx))
 
-				dogResult := router.Register(ctx, dogNS, generic.WrapAsync(dog))
+				dogResult := router.Register(ctx, dogRoute, generic.WrapAsync(dog))
 				ExpectResolveSuccess(dogResult.Get(ctx))
 
-				catResult := router.Register(ctx, catNS, generic.WrapAsync(cat))
+				catResult := router.Register(ctx, catRoute, generic.WrapAsync(cat))
 				ExpectResolveSuccess(catResult.Get(ctx))
 
 				return router
 			},
 			NewBackend: func() fakeBackend {
-				example, exampleNS = newFakeInserter(), changelog.Namespace("public.example")
-				dog, dogNS = newFakeInserter(), changelog.Namespace("public.dog")
-				cat, catNS = newFakeInserter(), changelog.Namespace("public.cat")
+				example, exampleRoute = newFakeInserter(), generic.Route("public.example")
+				dog, dogRoute = newFakeInserter(), generic.Route("public.dog")
+				cat, catRoute = newFakeInserter(), generic.Route("public.cat")
 
 				return newFakeBackend(example, dog, cat)
 			},

--- a/pkg/sinks/generic/sink.go
+++ b/pkg/sinks/generic/sink.go
@@ -123,14 +123,14 @@ func (s *sink) handleSchema(ctx context.Context, schema *changelog.Schema) error
 	logger := kitlog.With(s.logger, "event", "handle_schema", "namespace", string(schema.Spec.Namespace))
 	defer logger.Log()
 
-	route, inserter, outcome, err := s.schemaHandler.Handle(ctx, s.logger, schema)
-	logger = kitlog.With(logger, "route", string(route), "outcome", string(outcome))
+	inserter, outcome, err := s.schemaHandler.Handle(ctx, s.logger, schema)
+	logger = kitlog.With(logger, "outcome", string(outcome))
 	if err != nil {
 		return err
 	}
 
 	if outcome == SchemaHandlerUpdate {
-		s.router.Register(ctx, route, s.buildInserter(inserter))
+		s.router.Register(ctx, Route(schema.Spec.Namespace), s.buildInserter(inserter))
 	}
 
 	return nil


### PR DESCRIPTION
A SchemaHandler shouldn't have to worry about how we'll route
modification to this inserter. The contract is that we'll return an
Inserter that is valid for modifications matching this schema. We can
safely hardcode that we use the schema Namespace as a routing key into
our generic sink implementation.

This commit removes the RouteMatchAll value that was previously used to
tell the Router to map all incoming modifications to the same inserter.
We'll now have many routes pointing at the same inserter, but that's
probably ok.